### PR TITLE
added short_id and url_photo

### DIFF
--- a/georss_ingv_centro_nazionale_terremoti_client/__init__.py
+++ b/georss_ingv_centro_nazionale_terremoti_client/__init__.py
@@ -9,9 +9,13 @@ from georss_client import GeoRssFeed, FeedEntry
 from georss_client.consts import CUSTOM_ATTRIBUTE, ATTR_ATTRIBUTION
 from georss_client.feed_manager import FeedManagerBase
 
+IMAGE_URL_PATTERN = "http://shakemap.rm.ingv.it/shake/{}/download/intensity.jpg"
+
 REGEXP_ATTR_MAGNITUDE = r'Magnitude\(M.{{0,3}}\) (?P<{}>[^ ]+) '\
     .format(CUSTOM_ATTRIBUTE)
 REGEXP_ATTR_REGION = r'Magnitude\(M.{{0,3}}\) [^ ]+[ ]+-[ ]+(?P<{}>.+)$'\
+    .format(CUSTOM_ATTRIBUTE)
+REGEXP_ATTR_SHORT_ID = r'eventId=(?P<{}>\d+)$'\
     .format(CUSTOM_ATTRIBUTE)
 
 URL = "http://cnt.rm.ingv.it/feed/atom/all_week"
@@ -91,3 +95,15 @@ class IngvCentroNazionaleTerremotiFeedEntry(FeedEntry):
     def region(self) -> Optional[float]:
         """Return the region of this entry."""
         return self._search_in_title(REGEXP_ATTR_REGION)
+    
+    @property
+    def short_id(self) -> Optional[int]:
+        """Return the short id of this entry."""
+        return self._search_in_external_id(REGEXP_ATTR_SHORT_ID)
+
+    @property
+    def image_url(self) -> Optional[str]:
+        """Return the image url of this entry."""
+        if self.short_id and self.magnitude >= 3:
+            return IMAGE_URL_PATTERN.format(self.short_id) 
+        return None

--- a/georss_ingv_centro_nazionale_terremoti_client/__init__.py
+++ b/georss_ingv_centro_nazionale_terremoti_client/__init__.py
@@ -15,7 +15,7 @@ REGEXP_ATTR_MAGNITUDE = r'Magnitude\(M.{{0,3}}\) (?P<{}>[^ ]+) '\
     .format(CUSTOM_ATTRIBUTE)
 REGEXP_ATTR_REGION = r'Magnitude\(M.{{0,3}}\) [^ ]+[ ]+-[ ]+(?P<{}>.+)$'\
     .format(CUSTOM_ATTRIBUTE)
-REGEXP_ATTR_SHORT_ID = r'eventId=(?P<{}>\d+)$'\
+REGEXP_ATTR_EVENT_ID = r'eventId=(?P<{}>\d+)$'\
     .format(CUSTOM_ATTRIBUTE)
 
 URL = "http://cnt.rm.ingv.it/feed/atom/all_week"
@@ -97,13 +97,13 @@ class IngvCentroNazionaleTerremotiFeedEntry(FeedEntry):
         return self._search_in_title(REGEXP_ATTR_REGION)
     
     @property
-    def short_id(self) -> Optional[int]:
+    def event_id(self) -> Optional[int]:
         """Return the short id of this entry."""
-        return self._search_in_external_id(REGEXP_ATTR_SHORT_ID)
+        return self._search_in_external_id(REGEXP_ATTR_EVENT_ID)
 
     @property
     def image_url(self) -> Optional[str]:
         """Return the image url of this entry."""
-        if self.short_id and self.magnitude >= 3:
-            return IMAGE_URL_PATTERN.format(self.short_id) 
+        if self.event_id and self.magnitude >= 3:
+            return IMAGE_URL_PATTERN.format(self.event_id) 
         return None


### PR DESCRIPTION
Hi. I'm not a developer, but I propose this change. I have been using this system in Homeassistant for more than a year, copying your work from the ign_sismologia component.
I'd like to see your work integrated into homeassistant. Thanks for the attention.

[Here are the changes for homeassistant](
https://github.com/caiosweet/Package-Natural-Events/tree/caiosweet-patch-1/config/custom_components/ingv_centro_nazionale_terremoti)

Other types of images and urls
```
      [PGA](http://shakemap.rm.ingv.it/shake/f"{short_id}"/download/pga.jpg)
      [PGV](http://shakemap.rm.ingv.it/shake/f"{short_id}"/download/pgv.jpg)
      [TvMap](http://shakemap.rm.ingv.it/shake/f"{short_id}"/download/tvmap.jpg)
      [TvMap2](http://shakemap.rm.ingv.it/shake/f"{short_id}"/download/tvmap_bare.jpg)
```