### PR TITLE
IMAGE_URL_PATTERN link format changed.

### DIFF
--- a/georss_ingv_centro_nazionale_terremoti_client/consts.py
+++ b/georss_ingv_centro_nazionale_terremoti_client/consts.py
@@ -1,7 +1,7 @@
 """INGV Centro Nazionale Terremoti (Earthquakes) consts."""
 from georss_client import CUSTOM_ATTRIBUTE
 
-IMAGE_URL_PATTERN = "http://shakemap.rm.ingv.it/shake/{}/download/intensity.jpg"
+IMAGE_URL_PATTERN = "http://shakemap.rm.ingv.it/shake4/data/{}/current/products/intensity.jpg"
 
 REGEXP_ATTR_MAGNITUDE = r'Magnitude\(M.{{0,3}}\) (?P<{}>[^ ]+) '\
     .format(CUSTOM_ATTRIBUTE)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -67,7 +67,7 @@ class TestIngvCentroNazionaleTerremotiFeed(unittest.TestCase):
         feed_entry = entries[2]
         assert feed_entry.event_id == 3456
         assert feed_entry.image_url == "http://shakemap.rm.ingv.it/" \
-                                       "shake/3456/download/intensity.jpg"
+                                       "shake4/data/3456/current/products/intensity.jpg"
 
     @mock.patch("requests.Request")
     @mock.patch("requests.Session")


### PR DESCRIPTION
I found that the url of the image has changed, the new [ShakeMap v4](http://shakemap.rm.ingv.it/shake4/index.html) is now available. 
Thanks for your attention.